### PR TITLE
fix(chicken_states): menu confirm transitions + pause menu + session active state

### DIFF
--- a/crates/chicken_states/src/logic/menu/multiplayer.rs
+++ b/crates/chicken_states/src/logic/menu/multiplayer.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
-        events::menu::multiplayer::{
-            SetJoinGame, SetMultiplayerMenu, SetNewHostGame, SetSavedHostGame,
+        events::{
+            app::SetAppScope,
+            menu::multiplayer::{SetJoinGame, SetMultiplayerMenu, SetNewHostGame, SetSavedHostGame},
         },
         logic::session::server::PendingGoingPublic,
         states::{
@@ -293,6 +294,7 @@ fn on_set_new_host_game(
             next_session_type.set(SessionType::Singleplayer);
             next_server_status.set(ServerStatus::Starting);
             commands.insert_resource(PendingGoingPublic);
+            commands.trigger(SetAppScope::Session);
         }
 
         _ => {
@@ -381,6 +383,7 @@ fn on_set_saved_host_game(
             next_session_type.set(SessionType::Singleplayer);
             next_server_status.set(ServerStatus::Starting);
             commands.insert_resource(PendingGoingPublic);
+            commands.trigger(SetAppScope::Session);
         }
         _ => {
             let current = match current {

--- a/crates/chicken_states/src/logic/menu/singleplayer.rs
+++ b/crates/chicken_states/src/logic/menu/singleplayer.rs
@@ -3,7 +3,9 @@ use {
         events::menu::singleplayer::{
             SetSingleplayerMenu, SetSingleplayerNewGame, SetSingleplayerSavedGame,
         },
+        events::app::SetAppScope,
         states::{
+            app::AppScope,
             menu::{
                 main::MainMenuScreen,
                 singleplayer::{NewGameMenuScreen, SavedGameMenuScreen, SingleplayerMenuScreen},
@@ -11,7 +13,7 @@ use {
             session::{ServerStatus, SessionType},
         },
     },
-    bevy::prelude::{App, AppExtStates, NextState, On, Plugin, Res, ResMut, State, warn},
+    bevy::prelude::{App, AppExtStates, Commands, NextState, On, Plugin, Res, ResMut, State, warn},
 };
 
 pub(super) struct SingleplayerMenuPlugin;
@@ -238,6 +240,7 @@ fn on_set_singleplayer_menu(
 /// Handles SetSingleplayerNewGame events.
 fn on_set_singleplayer_new_game(
     event: On<SetSingleplayerNewGame>,
+    mut commands: Commands,
     current_parent: Res<State<SingleplayerMenuScreen>>,
     current: Option<Res<State<NewGameMenuScreen>>>,
     mut next_singleplayer: ResMut<NextState<SingleplayerMenuScreen>>,
@@ -278,6 +281,7 @@ fn on_set_singleplayer_new_game(
             }
             next_session_type.set(SessionType::Singleplayer);
             next_server_status.set(ServerStatus::Starting);
+            commands.trigger(SetAppScope::Session);
         }
         // Next/Previous: Navigate through config steps
         _ => {
@@ -325,6 +329,7 @@ fn on_set_singleplayer_new_game(
 /// Handles SetSingleplayerSavedGame events.
 fn on_set_singleplayer_saved_game(
     event: On<SetSingleplayerSavedGame>,
+    mut commands: Commands,
     current_parent: Res<State<SingleplayerMenuScreen>>,
     current: Option<Res<State<SavedGameMenuScreen>>>,
     mut next_singleplayer: ResMut<NextState<SingleplayerMenuScreen>>,
@@ -351,6 +356,7 @@ fn on_set_singleplayer_saved_game(
         SetSingleplayerSavedGame::Confirm => {
             next_session_type.set(SessionType::Singleplayer);
             next_server_status.set(ServerStatus::Starting);
+            commands.trigger(SetAppScope::Session);
         }
         // Next: Only one state, validate but effectively a no-op
         _ => {

--- a/crates/chicken_states/src/logic/session/server.rs
+++ b/crates/chicken_states/src/logic/session/server.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "hosted")]
-use crate::states::app::AppScope;
+use {
+    crate::states::app::AppScope,
+    bevy::prelude::{ButtonInput, IntoScheduleConfigs, KeyCode, SystemCondition, Update, in_state},
+};
 
 #[cfg(feature = "headless")]
 use {
@@ -37,6 +40,13 @@ impl Plugin for ServerSessionPlugin {
             .add_observer(on_server_shutdown_step)
             .add_observer(on_going_public_step)
             .add_observer(on_going_private_step);
+
+        #[cfg(feature = "hosted")]
+        app.add_systems(
+            Update,
+            toggle_pause_menu
+                .run_if(in_state(SessionState::Active).or(in_state(SessionState::Paused))),
+        );
     }
 }
 
@@ -147,6 +157,7 @@ fn on_server_startup_step(
     mut next_server_status: ResMut<NextState<ServerStatus>>,
     mut next_startup_step: Option<ResMut<NextState<ServerStartupStep>>>,
     mut next_session_type: ResMut<NextState<SessionType>>,
+    mut next_session_state: ResMut<NextState<SessionState>>,
     #[cfg(feature = "hosted")] mut next_app_scope: ResMut<NextState<AppScope>>,
     #[cfg(feature = "headless")] mut exit_writer: MessageWriter<AppExit>,
 ) {
@@ -213,6 +224,7 @@ fn on_server_startup_step(
                 }
                 (ServerStartupStep::Ready, SetServerStartupStep::Done) => {
                     next_server_status.set(ServerStatus::Running);
+                    next_session_state.set(SessionState::Active);
                 }
                 _ => {}
             }
@@ -548,6 +560,21 @@ fn on_going_private_step(
 
                 _ => {}
             }
+        }
+    }
+}
+
+#[cfg(feature = "hosted")]
+fn toggle_pause_menu(
+    current_state: Res<State<SessionState>>,
+    mut next_state: ResMut<NextState<SessionState>>,
+    keys: Res<ButtonInput<KeyCode>>,
+) {
+    if keys.just_pressed(KeyCode::Escape) {
+        match current_state.get() {
+            SessionState::Active => next_state.set(SessionState::Paused),
+            SessionState::Paused => next_state.set(SessionState::Active),
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Menu verschwindet nach Confirm nicht** — alle vier Confirm-Handler (`on_set_singleplayer_new_game`, `on_set_singleplayer_saved_game`, `on_set_new_host_game`, `on_set_saved_host_game`) feuerten kein `SetAppScope::Session`, weshalb die Menu-UI sichtbar blieb
- **SessionState blieb auf Setup** — bei `ServerStartupStep::Ready → Done` wurde `ServerStatus::Running` gesetzt, aber `SessionState::Active` nie — ESC und gameplay-systeme liefen deshalb nicht an
- **ESC öffnet Pause-Menu nicht** — `toggle_pause_menu` System unter `#[cfg(feature = "hosted")]` in `ServerSessionPlugin` registriert (zuvor nur im `ClientSessionPlugin`)

## Test plan

- [x] Singleplayer New Game starten → Menu-UI verschwindet
- [x] Singleplayer Load Game starten → Menu-UI verschwindet
- [x] Multiplayer Host New Game starten → Menu-UI verschwindet
- [x] Multiplayer Host Saved Game starten → Menu-UI verschwindet
- [x] ESC im laufenden Singleplayer öffnet Pause-Menu
- [x] ESC im Pause-Menu schließt es wieder
- [x] headless build kompiliert fehlerfrei

🤖 Generated with [Claude Code](https://claude.com/claude-code)