### PR TITLE
fix(chicken_network): register SessionRequest observer on WebTransportServer

### DIFF
--- a/crates/chicken_network/src/server/networking.rs
+++ b/crates/chicken_network/src/server/networking.rs
@@ -26,24 +26,17 @@ pub mod ports {
 }
 
 pub mod address {
-    // pub mod helpers {
-    //     use {
-    //         aeronet_webtransport::server::{SessionRequest, SessionResponse},
-    //         bevy::prelude::*,
-    //     };
+    pub mod helpers {
+        use {
+            aeronet_webtransport::server::{SessionRequest, SessionResponse},
+            bevy::prelude::*,
+        };
 
-    //     pub(super) fn handle_server_accept_connection(
-    //         client: Entity,
-    //         server: Entity,
-    //         mut trigger: On<SessionRequest>,
-    //     ) {
-    //         info!("{client} connecting to {server} with headers:");
-    //         for (header_key, header_value) in &trigger.headers {
-    //             info!("  {header_key}: {header_value}");
-    //         }
-
-    //         trigger.respond(SessionResponse::Accepted);
-    //     }
+        pub fn accept_session_request(mut trigger: On<SessionRequest>) {
+            // TODO: hier später Blacklist/Whitelist-Prüfung, Passwort, Server-voll-Check
+            trigger.respond(SessionResponse::Accepted);
+        }
+    }
 
     /// Get the local IP address of the server.
     pub fn get_local_ip() -> Option<std::net::IpAddr> {

--- a/crates/chicken_network/src/server/quic.rs
+++ b/crates/chicken_network/src/server/quic.rs
@@ -1,5 +1,5 @@
 use {
-    super::networking::ports,
+    super::networking::{address::helpers::accept_session_request, ports},
     aeronet::io::{connection::Disconnect, server::Close},
     aeronet_replicon::server::AeronetRepliconServer,
     aeronet_webtransport::{
@@ -119,10 +119,8 @@ fn server_going_public_starting_server(
 
     commands
         .spawn((Name::new("WebTransportServer"), AeronetRepliconServer))
-        .queue(WebTransportServer::open(config));
-    // .observe(on_server_is_public)
-    // .observe(on_server_session_request)
-    // .observe(on_server_client_disconnected);
+        .queue(WebTransportServer::open(config))
+        .observe(accept_session_request);
 
     commands.trigger(SetGoingPublicStep::Next);
 }


### PR DESCRIPTION
## Problem

Wenn sich ein Client per WebTransport verbinden wollte, panicte der Server:

```
dropped a `SessionRequest` without sending a response; you must respond to this request using `SessionRequest::respond`
```

Der `accept_session_request` Observer war auskommentiert und nie am `WebTransportServer` registriert — jede eingehende Verbindung wurde ignoriert und dann gedroppt.

## Fix

- `accept_session_request` in `networking.rs` reaktiviert und bereinigt
- Observer direkt am `WebTransportServer`-Entity in `server_going_public_starting_server` registriert

## Erweiterbarkeit

`accept_session_request` ist der zentrale Einstiegspunkt für spätere Validierung:
- Blacklist / Whitelist
- Server-Passwort
- Server-voll-Check

## Test plan

- [x] Client kann sich zu einem laufenden Multiplayer-Server verbinden
- [x] Server panickt nicht mehr beim ersten Verbindungsversuch
- [x] headless build kompiliert fehlerfrei (`--no-default-features --features server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)