### PR TITLE
fix(chicken_network): use global observer for SessionRequest

### DIFF
--- a/crates/chicken_network/src/server/quic.rs
+++ b/crates/chicken_network/src/server/quic.rs
@@ -21,6 +21,7 @@ pub(crate) struct QUICServerPlugin;
 impl Plugin for QUICServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(WebTransportServerPlugin)
+            .add_observer(accept_session_request)
             .add_systems(
                 OnEnter(GoingPublicStep::Validating),
                 server_going_public_validating,
@@ -119,8 +120,7 @@ fn server_going_public_starting_server(
 
     commands
         .spawn((Name::new("WebTransportServer"), AeronetRepliconServer))
-        .queue(WebTransportServer::open(config))
-        .observe(accept_session_request);
+        .queue(WebTransportServer::open(config));
 
     commands.trigger(SetGoingPublicStep::Next);
 }


### PR DESCRIPTION
## Problem

Der vorherige Fix (#29) hat `accept_session_request` als entity-scoped Observer am `WebTransportServer`-Entity registriert. `SessionRequest` wird aber global via `commands.trigger()` gefeuert — entity-scoped Observer werden dabei nicht aufgerufen.

Resultat: Panic blieb bestehen.

## Fix

`accept_session_request` wird jetzt als globaler Observer in `QUICServerPlugin::build()` registriert via `app.add_observer()`.

## Test plan

- [x] Client verbindet sich erfolgreich zu einem laufenden Multiplayer-Server
- [x] Kein Panic beim ersten Verbindungsversuch

🤖 Generated with [Claude Code](https://claude.com/claude-code)