### PR TITLE
fix(chat+network): chat end-to-end functional + client connection flow

### DIFF
--- a/crates/chicken/Cargo.toml
+++ b/crates/chicken/Cargo.toml
@@ -13,7 +13,7 @@ chicken_identity = { workspace = true }
 chicken_states = { workspace = true }
 chicken_notifications = { workspace = true }
 chicken_exitcodes = { workspace = true }
-chicken_protocols = { workspace = true }
+chicken_protocols = { workspace = true, features = ["server", "client"] }
 chicken_settings = { workspace = true }
 chicken_settings_content = { workspace = true }
 chicken_steam = { workspace = true }

--- a/crates/chicken_network/src/client.rs
+++ b/crates/chicken_network/src/client.rs
@@ -16,7 +16,7 @@ use {
     chicken_notifications::Notify,
     chicken_states::{
         events::session::{SetConnectingStep, SetDisconnectingStep, SetSyncingStep},
-        states::session::{ClientConnectionStatus, ConnectingStep, DisconnectingStep},
+        states::session::{ClientConnectionStatus, ConnectingStep, DisconnectingStep, SyncingStep},
     },
     discovery::ClientDiscoveryPlugin,
     helpers::client_config,
@@ -31,6 +31,10 @@ impl Plugin for ClientLogicPlugin {
             .add_systems(
                 OnEnter(ClientConnectionStatus::Connecting),
                 on_client_connecting,
+            )
+            .add_systems(
+                Update,
+                advance_connecting_steps.run_if(in_state(ClientConnectionStatus::Connecting)),
             )
             .add_systems(
                 Update,
@@ -254,27 +258,58 @@ fn on_client_connected(
     let name = names.get(target).ok();
     if let Some(name) = name {
         info!("Connected as {}", name.as_str());
-
-        let message = PlayerNameMessage {
+        ping.write(PlayerNameMessage {
             player_name: name.as_str().to_string(),
-        };
-        info!("Sent player name: {}", message.player_name);
-        // Nachricht senden
-        ping.write(message);
+        });
     } else {
         warn!("Session {} missing Name component", target);
     }
 
+    // Session established → OpeningConnection → Authenticating (identity sent above)
     commands.trigger(SetConnectingStep::Next);
 }
 
-fn client_syncing(mut commands: Commands) {
-    info!("TODO: Implement client sync system");
-    commands.trigger(SetConnectingStep::Done);
+/// Advances ConnectingStep while waiting for server auth response.
+/// `OpeningConnection` is driven by `on_client_connected` (On<Add, Session>).
+/// `Authenticating` and `WaitingForAccept` are placeholder auto-advances until
+/// a real server accept/reject message is implemented (see TODO in ConnectingStep).
+fn advance_connecting_steps(
+    step: Option<Res<State<ConnectingStep>>>,
+    mut commands: Commands,
+) {
+    let Some(step) = step else { return };
+
+    match step.get() {
+        ConnectingStep::OpeningConnection => {
+            // Waiting for On<Add, Session> — driven by on_client_connected
+        }
+        ConnectingStep::Authenticating | ConnectingStep::WaitingForAccept => {
+            // TODO: replace with real server accept/reject message
+            commands.trigger(SetConnectingStep::Next);
+        }
+        ConnectingStep::Ready => {
+            commands.trigger(SetConnectingStep::Done);
+        }
+    }
 }
 
-fn on_client_running(mut _commands: Commands) {
-    info!("Client is running");
+/// Advances SyncingStep one step per frame.
+/// TODO: replace with real world-sync logic (request world, receive chunks, spawn entities).
+fn client_syncing(step: Option<Res<State<SyncingStep>>>, mut commands: Commands) {
+    let Some(step) = step else { return };
+    match step.get() {
+        SyncingStep::RequestWorld | SyncingStep::ReceiveChunks | SyncingStep::SpawnEntities => {
+            commands.trigger(SetSyncingStep::Next);
+        }
+        SyncingStep::Ready => {
+            commands.trigger(SetSyncingStep::Done);
+        }
+    }
+}
+
+fn on_client_running(mut commands: Commands) {
+    info!("Client connected, starting sync");
+    commands.trigger(SetSyncingStep::Start);
 }
 
 fn client_disconnecting(

--- a/crates/chicken_protocols/Cargo.toml
+++ b/crates/chicken_protocols/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true, features = ["derive"] }
 
 [features]
 default = []
-server = ["bevy_replicon/server", "dep:chicken_states", "chicken_states/headless"]
+server = ["bevy_replicon/server", "dep:chicken_states"]
 client = ["bevy_replicon/client"]
 
 [lints]

--- a/crates/chicken_protocols/src/lib.rs
+++ b/crates/chicken_protocols/src/lib.rs
@@ -202,7 +202,14 @@ pub fn handle_client_chat(
 
         // TODO: Command-Parsing via extract_command() implementieren
         if extract_command(text).is_some() {
-            todo!("Chat-Commands sind noch nicht implementiert");
+            error_events.write(ToClients {
+                mode: SendMode::Direct(*client_id),
+                message: ServerChatError {
+                    error_type: ChatErrorType::UnknownCommand,
+                    message: "Chat-Commands sind noch nicht implementiert.".to_string(),
+                },
+            });
+            continue;
         }
 
         let identity = chat_identities.0.get(&client_id);

--- a/crates/chicken_states/src/logic/session/client.rs
+++ b/crates/chicken_states/src/logic/session/client.rs
@@ -147,10 +147,9 @@ pub(crate) fn is_valid_connecting_step_transition(
 ) -> bool {
     matches!(
         (from, to),
-        (ConnectingStep::ResolveAddress, SetConnectingStep::Next)
-            | (ConnectingStep::OpenSocket, SetConnectingStep::Next)
-            | (ConnectingStep::SendHandshake, SetConnectingStep::Next)
-            | (ConnectingStep::WaitForAccept, SetConnectingStep::Next)
+        (ConnectingStep::OpeningConnection, SetConnectingStep::Next)
+            | (ConnectingStep::Authenticating, SetConnectingStep::Next)
+            | (ConnectingStep::WaitingForAccept, SetConnectingStep::Next)
             | (ConnectingStep::Ready, SetConnectingStep::Done)
             | (_, SetConnectingStep::Failed)
     )
@@ -240,22 +239,17 @@ fn on_connecting_step(
             }
 
             match (current, event.event()) {
-                (ConnectingStep::ResolveAddress, SetConnectingStep::Next) => {
+                (ConnectingStep::OpeningConnection, SetConnectingStep::Next) => {
                     if let Some(ref mut next_step) = next_connecting_step {
-                        next_step.set(ConnectingStep::OpenSocket);
+                        next_step.set(ConnectingStep::Authenticating);
                     }
                 }
-                (ConnectingStep::OpenSocket, SetConnectingStep::Next) => {
+                (ConnectingStep::Authenticating, SetConnectingStep::Next) => {
                     if let Some(ref mut next_step) = next_connecting_step {
-                        next_step.set(ConnectingStep::SendHandshake);
+                        next_step.set(ConnectingStep::WaitingForAccept);
                     }
                 }
-                (ConnectingStep::SendHandshake, SetConnectingStep::Next) => {
-                    if let Some(ref mut next_step) = next_connecting_step {
-                        next_step.set(ConnectingStep::WaitForAccept);
-                    }
-                }
-                (ConnectingStep::WaitForAccept, SetConnectingStep::Next) => {
+                (ConnectingStep::WaitingForAccept, SetConnectingStep::Next) => {
                     if let Some(ref mut next_step) = next_connecting_step {
                         next_step.set(ConnectingStep::Ready);
                     }
@@ -551,7 +545,7 @@ mod tests {
             assert_eq!(session_type.get(), &SessionType::Client);
 
             let connecting_step = app.world().resource::<State<ConnectingStep>>();
-            assert_eq!(connecting_step.get(), &ConnectingStep::ResolveAddress);
+            assert_eq!(connecting_step.get(), &ConnectingStep::OpeningConnection);
         }
 
         /// Führt den Verbindungsprozess fort
@@ -974,9 +968,9 @@ mod tests {
         /// Test: Gültige ConnectingStep-Übergänge werden als gültig erkannt.
         #[test]
         fn test_valid_connecting_step_transitions() {
-            // ResolveAddress → Next ist gültig
+            // OpeningConnection → Next ist gültig
             assert!(is_valid_connecting_step_transition(
-                &ConnectingStep::ResolveAddress,
+                &ConnectingStep::OpeningConnection,
                 &SetConnectingStep::Next
             ));
 
@@ -988,7 +982,7 @@ mod tests {
 
             // Jeder Step → Failed ist gültig
             assert!(is_valid_connecting_step_transition(
-                &ConnectingStep::ResolveAddress,
+                &ConnectingStep::OpeningConnection,
                 &SetConnectingStep::Failed
             ));
         }
@@ -1056,27 +1050,21 @@ mod tests {
                 &SetConnectingStep::Next
             ));
 
-            // ResolveAddress → Done ist ungültig (Noch nicht bereit)
+            // OpeningConnection → Done ist ungültig (Noch nicht bereit)
             assert!(!is_valid_connecting_step_transition(
-                &ConnectingStep::ResolveAddress,
+                &ConnectingStep::OpeningConnection,
                 &SetConnectingStep::Done
             ));
 
-            // OpenSocket → Done ist ungültig (Noch nicht bereit)
+            // Authenticating → Done ist ungültig (Noch nicht bereit)
             assert!(!is_valid_connecting_step_transition(
-                &ConnectingStep::OpenSocket,
+                &ConnectingStep::Authenticating,
                 &SetConnectingStep::Done
             ));
 
-            // SendHandshake → Done ist ungültig (Noch nicht bereit)
+            // WaitingForAccept → Done ist ungültig (Noch nicht bereit)
             assert!(!is_valid_connecting_step_transition(
-                &ConnectingStep::SendHandshake,
-                &SetConnectingStep::Done
-            ));
-
-            // WaitForAccept → Done ist ungültig (Noch nicht bereit)
-            assert!(!is_valid_connecting_step_transition(
-                &ConnectingStep::WaitForAccept,
+                &ConnectingStep::WaitingForAccept,
                 &SetConnectingStep::Done
             ));
         }

--- a/crates/chicken_states/src/states/session.rs
+++ b/crates/chicken_states/src/states/session.rs
@@ -240,16 +240,17 @@ pub enum ClientConnectionStatus {
 #[derive(SubStates, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect)]
 #[source(ClientConnectionStatus = ClientConnectionStatus::Connecting)]
 pub enum ConnectingStep {
-    /// Resolve the server address (DNS or IP).
+    /// WebTransport connection is being established (DNS, QUIC, TLS).
+    /// Advances to `Authenticating` once the network session exists (`On<Add, Session>`).
     #[default]
-    ResolveAddress,
-    /// Open a socket connection to the server.
-    OpenSocket,
-    /// Send the initial handshake packet.
-    SendHandshake,
-    /// Wait for server acceptance response.
-    WaitForAccept,
-    /// Connection fully established.
+    OpeningConnection,
+    /// Session open. Client sends identity/auth token to the server.
+    /// TODO: replace auto-advance with real server accept message.
+    Authenticating,
+    /// Server is validating the client's identity/auth.
+    /// TODO: replace auto-advance with server-side accept/reject response.
+    WaitingForAccept,
+    /// Server accepted the client. Transitioning to `Connected`.
     Ready,
 }
 

--- a/crates/chicken_states/tests/common/mod.rs
+++ b/crates/chicken_states/tests/common/mod.rs
@@ -469,7 +469,7 @@ pub fn assert_server_startup_step(app: &mut App, expected: ServerStartupStep) {
 
 /// Number of Next steps to reach Ready during connecting.
 #[cfg(feature = "hosted")]
-pub const CLIENT_CONNECTING_STEPS: u8 = 4;
+pub const CLIENT_CONNECTING_STEPS: u8 = 3;
 /// Number of Next steps to reach Ready during syncing.
 #[cfg(feature = "hosted")]
 pub const CLIENT_SYNCING_STEPS: u8 = 3;

--- a/crates/chicken_states/tests/session_client/main.rs
+++ b/crates/chicken_states/tests/session_client/main.rs
@@ -14,7 +14,7 @@ use chicken_states::{
 // Connecting — Menu → Client (JoinGame → Confirm → Connecting)
 // =============================================================================
 
-/// JoinGame → Confirm immediately enters Connecting state (first step: ResolveAddress).
+/// JoinGame → Confirm immediately enters Connecting state (first step: OpeningConnection).
 /// Verifies all three state transitions set directly by Confirm.
 #[test]
 fn test_join_game_confirm_starts_connecting() {
@@ -23,7 +23,7 @@ fn test_join_game_confirm_starts_connecting() {
     common::assert_app_scope(&mut app, AppScope::Session);
     common::assert_session_type(&mut app, SessionType::Client);
     common::assert_client_status(&mut app, ClientConnectionStatus::Connecting);
-    common::assert_connecting_step(&mut app, ConnectingStep::ResolveAddress);
+    common::assert_connecting_step(&mut app, ConnectingStep::OpeningConnection);
 }
 
 /// Full connect flow: Connecting → (all steps) → Connected.


### PR DESCRIPTION
Closes #31

## Summary

- **Chat funktioniert jetzt end-to-end** (Singleplayer + Multiplayer Client)
- **Client-Chat-UI erscheint** nach dem Verbinden mit einem Server
- **Kein Panic** mehr bei `/`-Nachrichten

## Änderungen

### chicken_protocols
- `todo!()` bei Chat-Commands durch `ServerChatError::UnknownCommand` ersetzt
- `server` Feature entkoppelt von `chicken_states/headless` — hosted Apps bekommen jetzt server-seitige Chat-Handler
- `chicken` crate aktiviert `server + client` Features für `chicken_protocols`

### chicken_network
- Client-Connection-Flow gefixt: `on_client_connected` treibt `ConnectingStep` korrekt voran
- Neues System `advance_connecting_steps`: rückt `ConnectingStep` pro Frame vor sobald Session existiert
- `client_syncing` gefixt: rückt `SyncingStep` pro Frame vor (`RequestWorld → ReceiveChunks → SpawnEntities → Ready → Done`)
- `on_client_running` gefixt: triggert `SetSyncingStep::Start` → Client erreicht `Playing` + `SessionState::Active`

### chicken_states
- `ConnectingStep` Varianten auf App-Level-Semantik umbenannt:
  `ResolveAddress/OpenSocket/SendHandshake/WaitForAccept` → `OpeningConnection/Authenticating/WaitingForAccept/Ready`
- Validators, Observer und alle Tests aktualisiert

## Test plan
- [x] Singleplayer starten → Chat mit T/Enter öffnen → Nachricht schicken und anzeigen
- [x] Server hosten + Client verbinden → Client-Chat-UI erscheint nach Verbindung
- [x] `/command` eingeben → Error-Message statt Panic
- [x] `cargo test --package chicken_states --features hosted` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)