### PR TITLE
chore(states): reduce no-feature compile errors to single compile_error!

### DIFF
--- a/crates/chicken_states/src/logic/app.rs
+++ b/crates/chicken_states/src/logic/app.rs
@@ -1,10 +1,10 @@
 use {
-    crate::states::{
-        app::AppScope,
-        session::{SessionState, SessionType},
-    },
+    crate::states::app::AppScope,
     bevy::prelude::{App, AppExtStates, Plugin},
 };
+
+#[cfg(any(feature = "hosted", feature = "headless"))]
+use crate::states::session::{SessionState, SessionType};
 
 #[cfg(feature = "hosted")]
 use {
@@ -28,8 +28,9 @@ impl Plugin for AppLogicPlugin {
         if !app.is_plugin_added::<InputPlugin>() {
             app.add_plugins(InputPlugin);
         }
-        app.init_state::<AppScope>()
-            .init_state::<SessionType>()
+        app.init_state::<AppScope>();
+        #[cfg(any(feature = "hosted", feature = "headless"))]
+        app.init_state::<SessionType>()
             .add_sub_state::<SessionState>();
 
         #[cfg(feature = "hosted")]

--- a/crates/chicken_states/src/logic/session/server.rs
+++ b/crates/chicken_states/src/logic/session/server.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "hosted", feature = "headless"))]
+
 #[cfg(feature = "hosted")]
 use {
     crate::states::app::AppScope,

--- a/crates/chicken_states/src/states/app.rs
+++ b/crates/chicken_states/src/states/app.rs
@@ -26,5 +26,9 @@ impl Default for AppScope {
         // Dedicated Server starts directly in Session
         #[cfg(feature = "headless")]
         return AppScope::Session;
+
+        // Unreachable: compile_error! in lib.rs fires first when no feature is enabled
+        #[cfg(not(any(feature = "hosted", feature = "headless")))]
+        return AppScope::Session;
     }
 }

--- a/crates/chicken_states/src/states/session.rs
+++ b/crates/chicken_states/src/states/session.rs
@@ -4,6 +4,7 @@ use {
 };
 
 /// Defines the type of session.
+#[cfg(any(feature = "hosted", feature = "headless"))]
 #[derive(States, Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Reflect)]
 pub enum SessionType {
     /// This is active if there is no active game running, for example when the game is in the main menu.
@@ -113,6 +114,7 @@ pub enum ServerStatus {
 ///
 /// When a server transitions to `Starting`, it progresses through
 /// these steps to ensure proper initialization of all server components.
+#[cfg(any(feature = "hosted", feature = "headless"))]
 #[derive(SubStates, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect)]
 #[source(ServerStatus = ServerStatus::Starting)]
 pub enum ServerStartupStep {
@@ -132,6 +134,7 @@ pub enum ServerStartupStep {
 ///
 /// When a server transitions to `Stopping`, it progresses through
 /// these steps to ensure clean teardown of all session components.
+#[cfg(any(feature = "hosted", feature = "headless"))]
 #[derive(SubStates, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect)]
 #[source(ServerStatus = ServerStatus::Stopping)]
 pub enum ServerShutdownStep {
@@ -156,6 +159,7 @@ pub enum ServerShutdownStep {
 /// Manages the server's presence in public server listings, including
 /// transitions between private and public states. The server can be
 /// private (invisible), public (listed), or in transition between these states.
+#[cfg(any(feature = "hosted", feature = "headless"))]
 #[derive(SubStates, Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Reflect)]
 #[source(ServerStatus = ServerStatus::Running)]
 pub enum ServerVisibility {
@@ -174,6 +178,7 @@ pub enum ServerVisibility {
 ///
 /// When a server transitions to `GoingPublic`, it progresses through
 /// these steps to register with discovery services and become publicly listed.
+#[cfg(any(feature = "hosted", feature = "headless"))]
 #[derive(SubStates, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect)]
 #[source(ServerVisibility = ServerVisibility::GoingPublic)]
 pub enum GoingPublicStep {
@@ -192,6 +197,7 @@ pub enum GoingPublicStep {
 ///
 /// When a server transitions to `GoingPrivate`, it progresses through
 /// these steps to unregister from public listings and close public access.
+#[cfg(any(feature = "hosted", feature = "headless"))]
 #[derive(SubStates, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect)]
 #[source(ServerVisibility = ServerVisibility::GoingPrivate)]
 pub enum GoingPrivateStep {


### PR DESCRIPTION
Closes #11

## Summary
- `SessionType` und alle `ServerStatus`-abhängigen Typen in `#[cfg(any(feature = "hosted", feature = "headless"))]` gewrappt
- `logic/session/server.rs` bekommt ein file-level `#![cfg(...)]` inner attribute — kein per-Funktion Guard nötig
- `logic/app.rs` trennt den unconditional `use` sodass `SessionType`/`SessionState` nur unter einem Feature importiert werden
- `states/app.rs` `Default` impl bekommt einen no-feature Fallback um das `E0308` Noise zu unterdrücken

## Before
```
cargo build -p chicken_states  →  9 errors
```

## After
```
cargo build -p chicken_states  →  1 error: "You must enable either the 'hosted' or 'headless' feature"
```

## Test plan
- [x] `cargo build -p chicken_states` → genau 1 `compile_error!`
- [x] `cargo build -p chicken_states --features hosted` → clean
- [x] `cargo build -p chicken_states --features headless` → clean
- [x] `cargo test -p chicken_states --features hosted` → alle 10 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)