### PR TITLE
refactor(protocols+chicken): replace server/client features with hosted/headless

### DIFF
--- a/crates/chicken/Cargo.toml
+++ b/crates/chicken/Cargo.toml
@@ -13,7 +13,7 @@ chicken_identity = { workspace = true }
 chicken_states = { workspace = true }
 chicken_notifications = { workspace = true }
 chicken_exitcodes = { workspace = true }
-chicken_protocols = { workspace = true, features = ["server", "client"] }
+chicken_protocols = { workspace = true }
 chicken_settings = { workspace = true }
 chicken_settings_content = { workspace = true }
 chicken_steam = { workspace = true }
@@ -24,6 +24,16 @@ bevy = { workspace = true }
 
 
 [features]
+hosted = [
+    "chicken_states/hosted",
+    "chicken_protocols/hosted",
+    "chicken_network/client",
+]
+headless = [
+    "chicken_states/headless",
+    "chicken_protocols/headless",
+    "chicken_network/server",
+]
 example_bevy3d = ["bevy/3d"]
 
 

--- a/crates/chicken_protocols/Cargo.toml
+++ b/crates/chicken_protocols/Cargo.toml
@@ -20,8 +20,8 @@ serde = { workspace = true, features = ["derive"] }
 
 [features]
 default = []
-server = ["bevy_replicon/server", "dep:chicken_states"]
-client = ["bevy_replicon/client"]
+hosted = ["bevy_replicon/server", "bevy_replicon/client", "dep:chicken_states", "chicken_states/hosted"]
+headless = ["bevy_replicon/server", "dep:chicken_states", "chicken_states/headless"]
 
 [lints]
 workspace = true

--- a/crates/chicken_protocols/src/lib.rs
+++ b/crates/chicken_protocols/src/lib.rs
@@ -10,7 +10,7 @@ use {
     std::collections::{HashMap, VecDeque},
 };
 
-#[cfg(feature = "server")]
+#[cfg(any(feature = "hosted", feature = "headless"))]
 use chicken_states::states::session::ServerStatus;
 
 // ─── Konstanten ──────────────────────────────────────────────────────────────
@@ -43,7 +43,7 @@ impl Plugin for ProtocolPlugin {
             .add_server_message::<ServerChatError>(Channel::Ordered)
             .add_server_message::<ServerChatAutocomplete>(Channel::Ordered);
 
-        #[cfg(feature = "server")]
+        #[cfg(any(feature = "hosted", feature = "headless"))]
         app.add_systems(
             Update,
             (

--- a/xtask/src/config.rs
+++ b/xtask/src/config.rs
@@ -43,9 +43,8 @@ pub const CRATES: &[CrateConfig] = &[
         name: "chicken_protocols",
         features: &[
             ("default", ""),
-            ("server", "server"),
-            ("client", "client"),
-            ("all", "server,client"),
+            ("hosted", "hosted"),
+            ("headless", "headless"),
         ],
         test_threads_1: false,
         integration_tests: &[],


### PR DESCRIPTION
Closes #26

## Summary
- `chicken_protocols`: `server`/`client` → `hosted`/`headless`
  - `hosted` = server+client replicon code + `chicken_states/hosted`
  - `headless` = server-only replicon code + `chicken_states/headless`
  - Shared cfg guards: `#[cfg(any(feature = "hosted", feature = "headless"))]`
- `chicken` crate: bekommt `hosted`/`headless` Features die alles zu den Sub-Crates durchketten — kein Default mehr
- `xtask/config.rs`: CI-Feature-Liste auf neue Namen aktualisiert

## Warum
`--features server,client` aktivierte `chicken_states` ohne `hosted`/`headless` → `compile_error!` im CI.
Jetzt wählt der Aufrufer explizit `hosted` oder `headless`, analog zu `chicken_states`.

## Test plan
- [x] `cargo build -p chicken_protocols --features hosted` → clean
- [x] `cargo build -p chicken_protocols --features headless` → clean
- [x] `cargo build -p chicken --features hosted` → clean
- [x] `cargo build -p xtask` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)